### PR TITLE
change travis file to cache: packages and sudo: false to speed up builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: r
+sudo: false
+cache: packages
 
 r_github_packages:
  - jimhester/covr


### PR DESCRIPTION
hey @kylehamilton   - going through all ropensci repos trying to speed up Travis builds by using container based builds whenever possible 

the build https://travis-ci.org/ropensci/RCryptsy/builds/209092641 isn't faster than the others on the first run, but should be faster the next time since deps are cached